### PR TITLE
#29 - a-iot 빌드 실패 수정

### DIFF
--- a/apps/a-iot/src/stores/authStore.ts
+++ b/apps/a-iot/src/stores/authStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { UserResponse } from '@plug-atlas/types'
 
-interface AuthState {
+export interface AuthState {
   user: UserResponse | null
   isAuthenticated: boolean
   token: string | null

--- a/packages/ui/src/molecules/sonner/sonner.component.tsx
+++ b/packages/ui/src/molecules/sonner/sonner.component.tsx
@@ -1,5 +1,5 @@
 import { Toaster as Sonner, toast } from "sonner"
-import { cn } from "../../lib/utils"
+import type React from "react"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -76,7 +76,7 @@ const DefaultIcon = () => (
 )
 
 // Success Toast
-const toastSuccess = (message: string, options?: ToastOptions) => {
+const toastSuccess = (message: React.ReactNode, options?: ToastOptions) => {
   return toast(message, {
     description: options?.description,
     duration: options?.duration,
@@ -92,7 +92,7 @@ const toastSuccess = (message: string, options?: ToastOptions) => {
 }
 
 // Warning Toast
-const toastWarning = (message: string, options?: ToastOptions) => {
+const toastWarning = (message: React.ReactNode, options?: ToastOptions) => {
   return toast(message, {
     description: options?.description,
     duration: options?.duration,
@@ -108,7 +108,7 @@ const toastWarning = (message: string, options?: ToastOptions) => {
 }
 
 // Error Toast
-const toastError = (message: string, options?: ToastOptions) => {
+const toastError = (message: React.ReactNode, options?: ToastOptions) => {
   return toast(message, {
     description: options?.description,
     duration: options?.duration,
@@ -124,7 +124,7 @@ const toastError = (message: string, options?: ToastOptions) => {
 }
 
 // Info Toast
-const toastInfo = (message: string, options?: ToastOptions) => {
+const toastInfo = (message: React.ReactNode, options?: ToastOptions) => {
   return toast(message, {
     description: options?.description,
     duration: options?.duration,
@@ -140,7 +140,7 @@ const toastInfo = (message: string, options?: ToastOptions) => {
 }
 
 // Default Toast
-const toastDefault = (message: string, options?: ToastOptions) => {
+const toastDefault = (message: React.ReactNode, options?: ToastOptions) => {
   return toast(message, {
     description: options?.description,
     duration: options?.duration,
@@ -158,19 +158,19 @@ const toastDefault = (message: string, options?: ToastOptions) => {
 // 통합된 toast 객체 타입
 type BaseToastFn = typeof toast
 type ColoredToast = BaseToastFn & {
-  success: typeof toastSuccess
-  warning: typeof toastWarning
-  error: typeof toastError
-  info: typeof toastInfo
-  default: typeof toastDefault
+  success: (message: React.ReactNode, options?: ToastOptions) => string | number
+  warning: (message: React.ReactNode, options?: ToastOptions) => string | number
+  error: (message: React.ReactNode, options?: ToastOptions) => string | number
+  info: (message: React.ReactNode, options?: ToastOptions) => string | number
+  default: (message: React.ReactNode, options?: ToastOptions) => string | number
 }
 
 // toast 객체 확장
 const extendedToast = toast as ColoredToast
-extendedToast.success = toastSuccess
-extendedToast.warning = toastWarning
-extendedToast.error = toastError
-extendedToast.info = toastInfo
-extendedToast.default = toastDefault
+extendedToast.success = toastSuccess as any
+extendedToast.warning = toastWarning as any
+extendedToast.error = toastError as any
+extendedToast.info = toastInfo as any
+extendedToast.default = toastDefault as any
 
 export { Toaster, extendedToast as toast }


### PR DESCRIPTION
## Summary

- TypeScript 타입 오류로 인한 a-iot 앱 빌드 실패 수정
- sonner 컴포넌트 타입 호환성 개선
- AuthState 인터페이스 export 누락 해결

## 주요 변경사항

### sonner.component.tsx (packages/ui)
- 미사용 `cn` import 제거 (`../../lib/utils` → `type React from "react"`)
- 커스텀 toast 함수들의 message 파라미터 타입을 `string` → `React.ReactNode`로 변경
- toast 객체 확장 시 타입 단언(`as any`) 적용으로 호환성 문제 해결

### authStore.ts (apps/a-iot)
- `AuthState` 인터페이스에 `export` 키워드 추가
- `stores/index.ts`에서 re-export 가능하도록 수정

## 수정된 오류

```
error TS6133: 'cn' is declared but its value is never read.
error TS2322: Type '(message: string, options?: ToastOptions) => string | number' is not assignable to type...
error TS2459: Module '"./authStore"' declares 'AuthState' locally, but it is not exported.
```

## Test plan

- [x] a-iot 앱 빌드 성공 확인 (`pnpm build`)
- [x] TypeScript 타입 체크 통과
- [x] 번들 생성 확인 (dist/index.html, assets)

## 관련 이슈

Closes #29