### PR TITLE
#56 - SideMenu 타입 정의 충돌 해결

### DIFF
--- a/packages/ui/src/organisms/side-menu/side-menu.types.ts
+++ b/packages/ui/src/organisms/side-menu/side-menu.types.ts
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
-export interface SideMenuProps extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root> {
+export interface SideMenuProps extends Omit<React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root>, 'children'> {
   defaultOpen?: boolean
   collapsible?: boolean
   children?: React.ReactNode | (({ open }: { open: boolean }) => React.ReactNode)


### PR DESCRIPTION
## Summary

SideMenu 컴포넌트의 타입 정의 충돌 문제를 해결했습니다.

- `SideMenuProps`에서 `CollapsiblePrimitive.Root`의 `children` 타입 충돌 해결
- `Omit<>` 유틸리티를 사용하여 children 속성 제외 후 재정의
- 함수형 children 패턴 지원 유지 (`children: ReactNode | ({ open }) => ReactNode`)
- TypeScript 컴파일 에러 (TS2430) 해결

## Changes

### Type Definition Fix

**Before:**
```typescript
export interface SideMenuProps extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root> {
  children?: React.ReactNode | (({ open }: { open: boolean }) => React.ReactNode)
}
```

**After:**
```typescript
export interface SideMenuProps extends Omit<React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root>, 'children'> {
  children?: React.ReactNode | (({ open }: { open: boolean }) => React.ReactNode)
}
```

## Test plan

- [x] TypeScript 컴파일 성공 확인 (`pnpm --filter a-iot type-check`)
- [x] 기존 SideMenu 컴포넌트 동작 정상 확인
- [x] 함수형 children 패턴 동작 확인 (`children={({ open }) => ...}`)

## Related Issues

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
